### PR TITLE
FX3U input/output monitor

### DIFF
--- a/include/IODispatcher.hpp
+++ b/include/IODispatcher.hpp
@@ -1,0 +1,74 @@
+#include "IOUnit.hpp"
+
+#ifndef _iodispatcher_hpp
+#define _iodispatcher_hpp
+
+/* Relay */
+#define Y00 PC9
+#define Y01 PC8
+#define Y02 PA8
+#define Y03 PA0
+#define Y04 PB3
+#define Y05 PD12
+
+/* Digital IN */
+#define X00 PB13
+#define X01 PB14
+#define X02 PB11
+#define X03 PB12
+#define X04 PE15
+#define X05 PB10
+#define X06 PE13
+#define X07 PE14
+
+/* Analog IN */
+#define AD0 PA1
+#define AD1 PA3 
+#define AD2 PC4
+#define AD3 PC5
+#define AD4 PC0
+#define AD5 PC1
+
+/* Physical mapping */
+#define HEATER_PIN              Y00
+#define MIXER_PIN               Y01
+#define WJACKET_VALVE_PIN       Y02
+#define BLOWGUN_PUMP_PIN        Y03
+
+#define WJACKET_SENSOR_PIN      X00
+#define STOPBTN_PIN             X01
+#define MIXER_CRASH_SIGNAL_PIN  X02
+#define V380_SENSOR_PIN         X03
+#define BLOWGUN_SENSOR          X04
+
+#define BATTERY_CHARGE_PIN      AD0
+#define LIQUID_TEMPC_PIN        AD3
+
+const uint8_t c_io_array_size = 11;
+
+class IODispatcher
+{
+private:
+    IOUnit *io_array;
+
+protected:
+    IOUnit heater_r = IOUnit(HEATER_PIN, mode::Relay),
+           mixer_r = IOUnit(MIXER_PIN, mode::Relay),
+           water_jacket_r = IOUnit(WJACKET_VALVE_PIN, mode::Relay),
+           blowgun_r = IOUnit(BLOWGUN_PUMP_PIN, mode::Relay),
+           water_jacket_s = IOUnit(WJACKET_SENSOR_PIN, mode::DigitalIN),
+           stop_btn_s = IOUnit(STOPBTN_PIN, mode::DigitalIN),
+           mixer_crash_s = IOUnit(MIXER_CRASH_SIGNAL_PIN, mode::DigitalIN),
+           v380_s = IOUnit(V380_SENSOR_PIN, mode::DigitalIN),
+           blowgun_s = IOUnit(BLOWGUN_SENSOR, mode::DigitalIN),
+           battery_s = IOUnit(BATTERY_CHARGE_PIN, mode::AnalogIN),
+           liquid_temp_s = IOUnit(LIQUID_TEMPC_PIN, mode::AnalogIN);
+
+    bool init();
+    void relaysOff();
+
+public:
+    
+};
+
+#endif

--- a/include/IOUnit.hpp
+++ b/include/IOUnit.hpp
@@ -1,0 +1,21 @@
+#include <Arduino.h>
+
+#ifndef _iounit_hpp
+#define _iounit_hpp
+
+enum class mode { None, Relay, DigitalIN, AnalogIN };
+
+class IOUnit
+{
+private:
+    uint8_t stm_pin = 0;
+    mode pin_mode = mode::None;
+
+public:
+    IOUnit(uint8_t stm_pin, mode pin_mode);
+    void init();
+    bool write(bool value);
+    uint8_t read();
+};
+
+#endif

--- a/include/IOUnit.hpp
+++ b/include/IOUnit.hpp
@@ -13,9 +13,10 @@ private:
 
 public:
     IOUnit(uint8_t stm_pin, mode pin_mode);
-    void init();
+    bool init();
     bool write(bool value);
-    uint8_t read();
+    uint32_t read();
+    bool isAnalog();
 };
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,8 @@
 platform = ststm32
 board = genericSTM32F103VC
 framework = arduino
+upload_protocol = stlink
+debug_tool = stlink
+
+monitor_port = COM4
+monitor_speed = 38400

--- a/src/IODispatcher.cpp
+++ b/src/IODispatcher.cpp
@@ -1,0 +1,30 @@
+#include "IODispatcher.hpp"
+
+bool IODispatcher::init()
+{
+    io_array = new IOUnit[c_io_array_size] {
+        heater_r,
+        mixer_r,
+        water_jacket_r,
+        blowgun_r,
+        water_jacket_s,
+        stop_btn_s,
+        mixer_crash_s,
+        v380_s,
+        blowgun_s,
+        battery_s,
+        liquid_temp_s
+    };
+
+    for (uint8_t i = 0; i < c_io_array_size; i++)
+        if (!this->io_array[i].init())
+            return false;
+
+    return true;
+}
+
+void IODispatcher::relaysOff()
+{
+    for (uint8_t i = 0; i < c_io_array_size; i++)
+        this->io_array[i].write(false);
+}

--- a/src/IOUnit.cpp
+++ b/src/IOUnit.cpp
@@ -6,26 +6,43 @@ IOUnit::IOUnit(uint8_t stm_pin, mode pin_mode)
     this->pin_mode = pin_mode;
 }
 
-void IOUnit::init()
+bool IOUnit::init()
 {
-    if (pin_mode != mode::None)
+    Serial.print(stm_pin);
+    Serial.print(", ");
+    Serial.println((uint8_t)pin_mode);
+
+    if (pin_mode == mode::None)
+        return false;
+
     switch (pin_mode)
     {
-        case mode::Relay: pinMode(stm_pin, OUTPUT); break;
+        case mode::Relay: {
+            pinMode(stm_pin, OUTPUT);
+            digitalWrite(stm_pin, LOW);
+        } break;
         default: pinMode(stm_pin, INPUT); break;
     }
+    return true;
 }
 
 bool IOUnit::write(bool value)
 {
-    if (pin_mode == mode::Relay)
-        digitalWrite(stm_pin, value ? HIGH : LOW);
+    if (pin_mode != mode::Relay)
+        return false;
+    
+    digitalWrite(stm_pin, value ? HIGH : LOW);
+    return true;
 }
 
-uint8_t IOUnit::read()
+uint32_t IOUnit::read()
 {
     if (pin_mode == mode::AnalogIN)
         return analogRead(stm_pin);
     else
-        return digitalRead(stm_pin);
+        return digitalRead(stm_pin) == HIGH ? 1 : 0;
+}
+
+bool IOUnit::isAnalog() {
+    return this->pin_mode == mode::AnalogIN ? true : false;
 }

--- a/src/IOUnit.cpp
+++ b/src/IOUnit.cpp
@@ -1,0 +1,31 @@
+#include "IOUnit.hpp"
+
+IOUnit::IOUnit(uint8_t stm_pin, mode pin_mode)
+{
+    this->stm_pin = stm_pin;
+    this->pin_mode = pin_mode;
+}
+
+void IOUnit::init()
+{
+    if (pin_mode != mode::None)
+    switch (pin_mode)
+    {
+        case mode::Relay: pinMode(stm_pin, OUTPUT); break;
+        default: pinMode(stm_pin, INPUT); break;
+    }
+}
+
+bool IOUnit::write(bool value)
+{
+    if (pin_mode == mode::Relay)
+        digitalWrite(stm_pin, value ? HIGH : LOW);
+}
+
+uint8_t IOUnit::read()
+{
+    if (pin_mode == mode::AnalogIN)
+        return analogRead(stm_pin);
+    else
+        return digitalRead(stm_pin);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,9 @@
 #include <Arduino.h>
 
-void setup() {
-  // put your setup code here, to run once:
+void setup()
+{
 }
 
-void loop() {
-  // put your main code here, to run repeatedly:
+void loop()
+{
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,13 @@
 #include <Arduino.h>
+#include "IODispatcher.hpp"
+
+IODispatcher io_monitor;
 
 void setup()
 {
+    Serial.setRx(PA10);
+    Serial.setTx(PA9);
+    Serial.begin(38400);
 }
 
 void loop()


### PR DESCRIPTION
## The IOMonitor
branch developed classes [ IOUnit ](#iounit) and [ IODispatcher ](#iodispatcher) designed to work with physically connected peripherals of the FX3U controller.

<a name="iounit"></a>
#### IOUnit
is a base class that will be used to create instances to handle controller inputs and outputs.
It stores the variables:
- pin number of the installed stm32f103 chip;
- contact mode.

Its main functionality includes reading and/or writing on the pin of the current (this) instance.

<a name="iodispatcher"></a>
#### IODispatcher
is a control class which ones task is:
- storing instances of peripheral management objects;
- functions of fast superstructures (in this merge only turning off all relays is implemented, there may be more to come).
For quick configurations the following functions are implemented #defines of peripheral.